### PR TITLE
Jitsi widget supports audio mute manipulation

### DIFF
--- a/web/app/widget-wrappers/jitsi/jitsi.component.ts
+++ b/web/app/widget-wrappers/jitsi/jitsi.component.ts
@@ -46,10 +46,38 @@ export class JitsiWidgetWrapperComponent extends CapableWidget implements OnInit
             $.getScript(widget.options.scriptUrl);
         });
         this.jitsiApiSubscription = ScalarWidgetApi.requestReceived.subscribe(request => {
-            if (request.action === "audioMuteToggle" && this.isJoined) {
-                this.jitsiApiObj.executeCommand('toggleAudio');
-                ScalarWidgetApi.replyAcknowledge(request);
+            if (!this.isJoined) {
+                return;
             }
+
+            switch (request.action) {
+            case "audioToggle":
+                this.jitsiApiObj.executeCommand('toggleAudio');
+                break;
+            case "audioMute":
+                this.jitsiApiObj.isAudioMuted().then((muted) => {
+                    // Toggle audio if Jitsi is not currently muted
+                    if (!muted) {
+                        this.jitsiApiObj.executeCommand('toggleAudio');
+                    }
+                });
+                break;
+            case "audioUnmute":
+                this.jitsiApiObj.isAudioMuted().then((muted) => {
+                    // Toggle audio if Jitsi is currently muted
+                    if (muted) {
+                        this.jitsiApiObj.executeCommand('toggleAudio');
+                    }
+                });
+                break;
+            default:
+                // Unknown command sent
+                return;
+            }
+
+            // TODO: Travis, should this fire even if we didn't get a command we're
+            // handling?
+            ScalarWidgetApi.replyAcknowledge(request);
         });
     }
 

--- a/web/app/widget-wrappers/jitsi/jitsi.component.ts
+++ b/web/app/widget-wrappers/jitsi/jitsi.component.ts
@@ -1,8 +1,10 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnDestroy, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import * as $ from "jquery";
 import { FE_JitsiWidget } from "../../shared/models/integration";
 import { WidgetApiService } from "../../shared/services/integrations/widget-api.service";
+import { Subscription } from "rxjs/Subscription";
+import { ScalarWidgetApi } from "../../shared/services/scalar/scalar-widget.api";
 import { CapableWidget } from "../capable-widget";
 
 declare var JitsiMeetExternalAPI: any;
@@ -12,7 +14,7 @@ declare var JitsiMeetExternalAPI: any;
     templateUrl: "jitsi.component.html",
     styleUrls: ["jitsi.component.scss"],
 })
-export class JitsiWidgetWrapperComponent extends CapableWidget implements OnInit {
+export class JitsiWidgetWrapperComponent extends CapableWidget implements OnInit, OnDestroy {
 
     public isJoined = false;
 
@@ -22,6 +24,7 @@ export class JitsiWidgetWrapperComponent extends CapableWidget implements OnInit
     private avatarUrl: string;
     private userId: string;
     private jitsiApiObj: any;
+    private jitsiApiSubscription: Subscription;
 
     constructor(activatedRoute: ActivatedRoute, private widgetApi: WidgetApiService) {
         super();
@@ -41,6 +44,12 @@ export class JitsiWidgetWrapperComponent extends CapableWidget implements OnInit
         this.widgetApi.getWidget("jitsi").then(integration => {
             const widget = <FE_JitsiWidget>integration;
             $.getScript(widget.options.scriptUrl);
+        });
+        this.jitsiApiSubscription = ScalarWidgetApi.requestReceived.subscribe(request => {
+            if (request.action === "audioMuteToggle" && this.isJoined) {
+                this.jitsiApiObj.executeCommand('toggleAudio');
+                ScalarWidgetApi.replyAcknowledge(request);
+            }
         });
     }
 
@@ -71,6 +80,10 @@ export class JitsiWidgetWrapperComponent extends CapableWidget implements OnInit
         });
 
         this.isJoined = true;
+    }
+
+    public ngOnDestroy() {
+        if (this.jitsiApiSubscription) this.jitsiApiSubscription.unsubscribe();
     }
 
 }

--- a/web/app/widget-wrappers/jitsi/jitsi.component.ts
+++ b/web/app/widget-wrappers/jitsi/jitsi.component.ts
@@ -75,8 +75,6 @@ export class JitsiWidgetWrapperComponent extends CapableWidget implements OnInit
                 return;
             }
 
-            // TODO: Travis, should this fire even if we didn't get a command we're
-            // handling?
             ScalarWidgetApi.replyAcknowledge(request);
         });
     }


### PR DESCRIPTION
Part of my push-to-talk work and handling https://github.com/vector-im/riot-web/issues/5993, adds an API to handle Jitsi audio toggle requests from Riot.

Eventually this will hopefully get an upgrade to allow for audio "mute" and "unmute" commands, but some other factors are blocking that at the moment, plus Jitsi's iframe API only allows for toggling, so some logic will be needed to determine the current state of the audio before determining if toggling is necessary.