### PR TITLE
Fix bugs related to custom sticker integration

### DIFF
--- a/web/app/configs/stickerpicker/stickerpicker.component.html
+++ b/web/app/configs/stickerpicker/stickerpicker.component.html
@@ -2,12 +2,12 @@
     <my-spinner></my-spinner>
 </div>
 <div *ngIf="!isLoading">
-    <my-ibox boxTitle="Sticker Packs" *ngIf="packs.length <= 0">
+    <my-ibox boxTitle="Sticker Packs" *ngIf="packs.length <= 0 && !customEnabled">
         <div class="my-ibox-content">
             <h5 style="text-align: center;">Sticker packs are not enabled on this Dimension instance.</h5>
         </div>
     </my-ibox>
-    <my-ibox boxTitle="Add Sticker Packs" *ngIf="packs.length > 0 && customEnabled">
+    <my-ibox boxTitle="Add Sticker Packs" *ngIf="customEnabled">
         <div class="my-ibox-content">
             <form (submit)="importPack()" novalidate name="importForm">
                 <label class="label-block">

--- a/web/app/configs/stickerpicker/stickerpicker.component.ts
+++ b/web/app/configs/stickerpicker/stickerpicker.component.ts
@@ -92,7 +92,7 @@ export class StickerpickerComponent implements OnInit {
 
             const targetUrl = this.window.location.origin + "/widgets/stickerpicker";
 
-            if (widgets.response[0].content.url === targetUrl) {
+            if (Array.isArray(widgets.response) && widgets.response.length && widgets.response[0].content.url === targetUrl) {
                 console.warn("Not replacing Dimension sticker picker");
                 return;
             }


### PR DESCRIPTION
This PR fixes two bugs related to custom sticker integration, one that is described in #288 and another one that would prevent the sticker picker from showing enabled stickerpacks if the `scalarClient` would return an empty list of widgets.