### PR TITLE
Make sticker picker mobile friendlier and fix sending from Riot Mobile

### DIFF
--- a/web/app/shared/services/scalar/scalar-widget.api.ts
+++ b/web/app/shared/services/scalar/scalar-widget.api.ts
@@ -43,6 +43,7 @@ export class ScalarWidgetApi {
             data: {
                 description: sticker.description,
                 content: {
+                    body: sticker.description,
                     url: sticker.thumbnail.mxc,
                     info: {
                         mimetype: sticker.image.mimetype,

--- a/web/app/shared/services/scalar/scalar-widget.api.ts
+++ b/web/app/shared/services/scalar/scalar-widget.api.ts
@@ -43,6 +43,7 @@ export class ScalarWidgetApi {
             data: {
                 description: sticker.description,
                 content: {
+                    // Riot Android needs body in content or else sticker sending fails
                     body: sticker.description,
                     url: sticker.thumbnail.mxc,
                     info: {

--- a/web/app/widget-wrappers/sticker-picker/sticker-picker.component.html
+++ b/web/app/widget-wrappers/sticker-picker/sticker-picker.component.html
@@ -27,7 +27,7 @@
             <div class="stickers">
                 <div class="sticker" *ngFor="let sticker of pack.stickers trackById"
                      (click)="sendSticker(sticker, pack)">
-                    <img [src]="getThumbnailUrl(sticker.thumbnail.mxc, 48, 48)" width="48" height="48" class="image"
+                    <img [src]="getThumbnailUrl(sticker.thumbnail.mxc, 48, 48)" class="image"
                          [alt]="sticker.name" [ngbTooltip]="sticker.name" placement="bottom"/>
                 </div>
             </div>

--- a/web/app/widget-wrappers/sticker-picker/sticker-picker.component.scss
+++ b/web/app/widget-wrappers/sticker-picker/sticker-picker.component.scss
@@ -49,6 +49,20 @@
         margin-top: 15px;
         margin-left: 3px;
 
+        @media screen and (max-resolution: 96dpi), (min-width: 740px) {
+          .title {
+            font-size: 3em;
+          }
+
+          .license {
+            font-size: 1.8em;
+          }
+
+          .author {
+            font-size: 1.8em;
+          }
+        }
+
         .title {
           font-weight: 700;
           color: themed(stickerPickerTitleColor);
@@ -81,14 +95,29 @@
       .stickers {
         display: flex;
         flex-wrap: wrap;
+        align-content: flex-start;
+        justify-content: space-between;
+
+        &:after {
+          content: "";
+          flex: auto;
+          flex-basis: 18%;
+        }
 
         .sticker {
-          padding: 5px;
+          flex-grow: 1;
+          flex-basis: 18%;
+          max-width: 18%;
           margin: 2px;
           cursor: pointer;
           border-radius: 3px;
           background-color: themed(stickerPickerStickerBgColor);
           box-shadow: 0 2px 6px themed(stickerPickerShadowColor);
+
+          img {
+            height: 100%;
+            width: 100%;
+          }
         }
       }
     }


### PR DESCRIPTION
This PR fixes a few issues for making the sticker picker more usable on Riot Mobile apps.

The sticker picker itself changes the title size and stickers to be more tapable on the mobile screen. There's currently a media rule because the WebView for Riot Mobile is not DPI aware which has to be worked around. It has also been tested on Riot Desktop and there is no usability issue. The stickers are now arranged in a 5 column layout.

The sendSticker function now sends a body with the sticker's description because Riot Android needs a body for the JSON content or else it throws it away making it fail to finish the event. This makes Dimension stickers finally usable on Android at least.

Related issues:
#59 Mobile app support