### PR TITLE
send stickers from element android

### DIFF
--- a/web/app/shared/services/scalar/scalar-widget.api.ts
+++ b/web/app/shared/services/scalar/scalar-widget.api.ts
@@ -41,8 +41,8 @@ export class ScalarWidgetApi {
     public static sendSticker(sticker: FE_Sticker, pack: FE_StickerPack): void {
         ScalarWidgetApi.callAction("m.sticker", {
             data: {
-                description: sticker.description,
                 content: {
+                    body: sticker.description,
                     url: sticker.thumbnail.mxc,
                     info: {
                         mimetype: sticker.image.mimetype,


### PR DESCRIPTION
I'm not sure if there are API versioning considerations to take into account, but I was unable to send any stickers from Android until this change was made to the widget response.