### PR TITLE
docker-entrypoint: exec node

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 if [ -f "/data/config.yaml" ]; then
 	cp /data/config.yaml /home/node/matrix-dimension/config/production.yaml
-	NODE_ENV=production node build/app/index.js
+	NODE_ENV=production exec node build/app/index.js
 else
 	cp /home/node/matrix-dimension/config/default.yaml /data/config.yaml
 	echo "A default config file has been placed in the /data/ volume please review and make any required changes and start the container again"


### PR DESCRIPTION
/bin/sh makes for a horrible PID 1, so exec node instead of having sh block signals going to it.
As recommended by: https://docs.docker.com/engine/reference/builder/#entrypoint