### PR TITLE
Fix the Greenlight URL method of BigBlueButton

### DIFF
--- a/web/app/configs/widget/bigbluebutton/bigbluebutton.widget.component.ts
+++ b/web/app/configs/widget/bigbluebutton/bigbluebutton.widget.component.ts
@@ -27,7 +27,6 @@ export class BigBlueButtonConfigComponent extends WidgetComponent {
 
     protected OnNewWidgetPrepared(widget: EditableWidget): void {
         widget.dimension.newData["conferenceUrl"] = this.bigBlueButtonWidget.options.conferenceUrl;
-        widget.dimension.newData["createMeeting"] = this.bigBlueButtonWidget.options.createMeeting;
     }
 
     protected OnWidgetBeforeAdd(widget: EditableWidget) {
@@ -44,7 +43,6 @@ export class BigBlueButtonConfigComponent extends WidgetComponent {
         let widgetQueryString = url.format({
             query: {
                 "conferenceUrl": "$conferenceUrl",
-                "createMeeting": "$createMeeting",
                 "displayName": "$matrix_display_name",
                 "avatarUrl": "$matrix_avatar_url",
                 "userId": "$matrix_user_id",


### PR DESCRIPTION
This PR fixes a bug in [the greenlight method](https://github.com/turt2live/matrix-dimension/blob/master/docs/bigbluebutton.md#usage-guide) of creating a BigBlueButton meeting, which was introduced in #413. 

We were accidentally setting the `createMeeting` query parameter to something (vaguely) truthy when creating a widget through Dimension's UI, which told the widget to use the non-UI method of connecting to a meeting:

https://github.com/turt2live/matrix-dimension/blob/b97a0f4bc2a6dc4e2b4080762d84dc659f539b77/web/app/widget-wrappers/bigbluebutton/bigbluebutton.component.ts#L134-L142

I believe this change will prevent the widget URL from containing the `createMeeting` query parameter when generating a widget through Dimension's UI (which is how users currently use the greenlight method).