### PR TITLE
Update link to Integration manager 

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -139,7 +139,7 @@ intended - double check that all the configuration is set up and visit [#dimensi
 for further help.
 
 After configuring Element, click the the "Add widgets, bridges & bots" link in the Room Info of any room and
-then click the gear icon. If you don't see a gear icon, you're not an admin in the config. Alternatively, open `https://dimension.<your-domain>.eu/riot-app/admin`. This is
+then click the gear icon. If you don't see a gear icon, you're not an admin in the config. Alternatively, open `https://dimension.<your-domain>/riot-app/admin`. This is
 where you'll configure different integrations as Dimension doesn't ship with anything enabled by
 default - click around and start enabling things.
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -138,8 +138,8 @@ and see instructions for configuring Element. If you don't, your configuration i
 intended - double check that all the configuration is set up and visit [#dimension:t2bot.io](https://matrix.to/#/#dimension:t2bot.io)
 for further help.
 
-After configuring Element, click the integrations button (4 squares in the top right of any room) and
-then click the gear icon. If you don't see a gear icon, you're not an admin in the config. This is
+After configuring Element, click the the "Add widgets, bridges & bots" link in the Room Info of any room and
+then click the gear icon. If you don't see a gear icon, you're not an admin in the config. Alternatively, open `https://dimension.<your-domain>.eu/riot-app/admin`. This is
 where you'll configure different integrations as Dimension doesn't ship with anything enabled by
 default - click around and start enabling things.
 


### PR DESCRIPTION
The four-squares-icon for integration management are apparently no longer a thing in the latest element. Also, just using the direct link avoids having to create a room.