### PR TITLE
Update URLs for neb bots

### DIFF
--- a/src/db/migrations/20210906225500-ChangeAvatarUrlForNeb.ts
+++ b/src/db/migrations/20210906225500-ChangeAvatarUrlForNeb.ts
@@ -1,0 +1,30 @@
+import { QueryInterface } from "sequelize";
+
+export default {
+    up: (queryInterface: QueryInterface) => {
+        return Promise.resolve()
+            .then(() =>
+                queryInterface.sequelize.query(
+                    "UPDATE dimension_appservice_users SET avatarUrl = REPLACE(avatarUrl, '/img/', '/assets/img/')"
+                )
+            )
+            .then(() =>
+                queryInterface.sequelize.query(
+                    "UPDATE dimension_neb_integrations SET avatarUrl = REPLACE(avatarUrl, '/img/', '/assets/img/')"
+                )
+            );
+    },
+    down: (queryInterface: QueryInterface) => {
+        return Promise.resolve()
+            .then(() =>
+                queryInterface.sequelize.query(
+                    "UPDATE dimension_appservice_users SET avatarUrl = REPLACE(avatarUrl, '/assets/img/', '/img/')"
+                )
+            )
+            .then(() =>
+                queryInterface.sequelize.query(
+                    "UPDATE dimension_neb_integrations SET avatarUrl = REPLACE(avatarUrl, '/assets/img/', '/img/')"
+                )
+            );
+    },
+};


### PR DESCRIPTION
The migration for replacing the path for avatar url is missing neb bots and thus show broken images. This should fix that at next run.