### PR TITLE
Small general fixes incl. toaster CSS, postgres, lazy loading for stickers

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -105,7 +105,7 @@ database:
 
 **Docker**:
 ```bash
-docker run -d --name dimension -p 127.0.0.1:8184:8184 -v /etc/dimension:/data turt2live/matrix-dimension
+docker run -d --name dimension -p 127.0.0.1:8184:8184 -v ./data:/data turt2live/matrix-dimension
 ```
 
 **Building**:

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -87,11 +87,17 @@ as an example, create a file at `/etc/dimension/config.yaml`.
 After creating the file, open it in an editor like `nano` and start filling in the details. Don't forget
 to add your user ID as an admin in the configuration - this is important later!
 
-If you're using Docker, leave the `web` `port` and `address` as-is. Additionally, make sure to configure
-the `database` section to look like this:
+If you're using Docker, leave the `web` `port` and `address` as-is. Dimension supports SQLite and PostgreSQL as the database. Make sure to configure the `database` section to look like this for SQLite:
 ```yaml
 database:
     file: "/data/dimension.db"
+    botData: "/data/bot.json"
+```
+
+or for PostgreSQL:
+```yaml
+database:
+    uri: "postgres://admin:password@localhost:5432/matrix-dimension"
     botData: "/data/bot.json"
 ```
 

--- a/web/app/app.module.ts
+++ b/web/app/app.module.ts
@@ -133,7 +133,7 @@ export function HttpLoaderFactory(http: HttpClient) {
         routing,
         NgbModule,
         UiSwitchModule,
-        ToasterModule,
+        ToasterModule.forRoot(),
         BrowserAnimationsModule,
         BreadcrumbModule,
         CKEditorModule,

--- a/web/app/widget-wrappers/sticker-picker/sticker-picker.component.html
+++ b/web/app/widget-wrappers/sticker-picker/sticker-picker.component.html
@@ -26,14 +26,14 @@
             <div class="stickers">
                 <div class="sticker" *ngFor="let sticker of pack.stickers trackById"
                      (click)="sendSticker(sticker, pack)">
-                    <img [src]="getThumbnailUrl(sticker.thumbnail.mxc, 48, 48)" width="48" height="48" class="image"
+                    <img [src]="getThumbnailUrl(sticker.thumbnail.mxc, 48, 48)" width="48" height="48" class="image" loading="lazy"
                          [alt]="sticker.name" [ngbTooltip]="sticker.name" placement="bottom"/>
                 </div>
             </div>
         </div>
         <div class="sticker-pack-list" [@hideList]="isListVisible ? 'visible' : 'hidden'" (wheel)="scrollHorizontal($event)" >
             <div class="sticker-pack-list-item" *ngFor="let pack of packs trackById" (click)="scrollToPack('pack-' + pack.id)">
-                <img [src]="getThumbnailUrl(pack.stickers[0].thumbnail.mxc, 48, 48)" width="40" height="40" class="image"
+                <img [src]="getThumbnailUrl(pack.stickers[0].thumbnail.mxc, 48, 48)" width="40" height="40" class="image" loading="lazy"
                          [alt]="pack.displayName" [ngbTooltip]="pack.displayName" placement="top" container="body"/>
             </div>
             <div class="sticker-pack-list-config" (click)="openIntegrationManager()"

--- a/web/style/app.scss
+++ b/web/style/app.scss
@@ -1,12 +1,12 @@
 // styles in src/style directory are applied to the whole page
 @import "../assets//fonts/opensans100-roboto300";
-@import "../../node_modules/angular2-toaster/toaster";
 @import "~bootstrap/scss/bootstrap";
 @import "~ngx-ui-switch/ui-switch.component.scss";
 @import "themes/themes";
 @import "components/ibox";
 @import "components/dialog";
 @import "components/bootstrap_override";
+@import "~angular2-toaster/toaster";
 @import "riot";
 
 body {

--- a/web/style/components/bootstrap_override.scss
+++ b/web/style/components/bootstrap_override.scss
@@ -27,5 +27,9 @@
     .form-control::placeholder {
       color: themed(formControlPlaceholderColor);
     }
+
+    .toast:not(.show) {
+      display: flex;
+    }
   }
 }


### PR DESCRIPTION
This PR contains a few small fixes and changes:

- Override the bootstrap toaster CSS, fixing toasters being invisible
- Mention Postgres and the URL setting in installation.md
- Change docker command in installation.md so it doesn't point volume to root-only /etc, closes #404 
- Use `loading=lazy` attribute for stickers. This should work on most modern browsers and helps reduce loading times and server load for the sticker picker