### PR TITLE
Reduce roomID length, limit Pad Name to 39 characters

### DIFF
--- a/web/app/configs/widget/etherpad/etherpad.widget.component.html
+++ b/web/app/configs/widget/etherpad/etherpad.widget.component.html
@@ -3,6 +3,7 @@
         <label class="label-block">
             {{'Pad Name' | translate}}
             <input type="text" class="form-control"
+                   maxlength="39"
                    placeholder="{{ defaultName }}"
                    [(ngModel)]="widget.dimension.newName" name="widget-name-{{widget.id}}"
                    [disabled]="isUpdating"/>

--- a/web/app/configs/widget/etherpad/etherpad.widget.component.ts
+++ b/web/app/configs/widget/etherpad/etherpad.widget.component.ts
@@ -40,7 +40,7 @@ export class EtherpadWidgetConfigComponent extends WidgetComponent {
             template = this.etherpadWidget.options.defaultUrl;
         }
 
-        template = template.replace("$roomId", encodeURIComponent(SessionStorage.roomId));
+        template = template.replace("$roomId", encodeURIComponent(SessionStorage.roomId).slice(0, 10));
         template = template.replace("$padName", encodeURIComponent(name));
 
         widget.dimension.newUrl = template;


### PR DESCRIPTION
This reduced the roomID length to the first 10 characters to keep the random name still to "the room". The Pad Name is also limited to 39 characters so the user doesn't accidentally go over 50 characters (10 c. roomId + _ + 39 c. pad name)

Fixes #395 