### PR TITLE
Fix iOS stickers by adding widgetData to callAction

### DIFF
--- a/web/app/shared/services/scalar/scalar-widget.api.ts
+++ b/web/app/shared/services/scalar/scalar-widget.api.ts
@@ -39,33 +39,36 @@ export class ScalarWidgetApi {
     }
 
     public static sendSticker(sticker: FE_Sticker, pack: FE_StickerPack): void {
-        ScalarWidgetApi.callAction("m.sticker", {
-            data: {
-                description: sticker.description,
-                content: {
-                    // Element Android requires content.body to contain the sticker description, otherwise
-                    // you will not be able to send any stickers
-                    body: sticker.description,
-                    url: sticker.thumbnail.mxc,
-                    info: {
+        const payload = {
+            description: sticker.description,
+            content: {
+                // Element Android requires content.body to contain the sticker description, otherwise
+                // you will not be able to send any stickers
+                body: sticker.description,
+                url: sticker.thumbnail.mxc,
+                info: {
+                    mimetype: sticker.image.mimetype,
+                    w: Math.round(sticker.thumbnail.width / 2),
+                    h: Math.round(sticker.thumbnail.height / 2),
+                    thumbnail_url: sticker.thumbnail.mxc,
+                    thumbnail_info: {
                         mimetype: sticker.image.mimetype,
                         w: Math.round(sticker.thumbnail.width / 2),
                         h: Math.round(sticker.thumbnail.height / 2),
-                        thumbnail_url: sticker.thumbnail.mxc,
-                        thumbnail_info: {
-                            mimetype: sticker.image.mimetype,
-                            w: Math.round(sticker.thumbnail.width / 2),
-                            h: Math.round(sticker.thumbnail.height / 2),
-                        },
+                    },
 
-                        // This has to be included in the info object so it makes it to the event
-                        dimension: {
-                            license: pack.license,
-                            author: pack.author,
-                        },
+                    // This has to be included in the info object so it makes it to the event
+                    dimension: {
+                        license: pack.license,
+                        author: pack.author,
                     },
                 },
             },
+        };
+        ScalarWidgetApi.callAction("m.sticker", {
+            data: payload,
+            // This is needed for Element iOS to work as it uses widgetData
+            widgetData: payload,
         });
     }
 


### PR DESCRIPTION
This fixes sending stickers on iOS by essentially reusing the `data` payload and adding it to `widgetData`.

Unfortunately it seems like Element iOS doesn't look in data but widgetData. Having both in the action payload allows compatibility with any client.

The solution is pretty similar to how maunium's stickerpicker works.