### PR TITLE
fix room creation on bigbluebutton 2.4+

### DIFF
--- a/src/api/dimension/DimensionBigBlueButtonService.ts
+++ b/src/api/dimension/DimensionBigBlueButtonService.ts
@@ -192,6 +192,7 @@ export class DimensionBigBlueButtonService {
 
         // NOTE: BBB meetings will by default end a minute or two after the last person leaves.
         const createQueryParameters = {
+            name: roomId,
             meetingID: randomString(20),
             // To help admins link meeting IDs to rooms
             meta_MatrixRoomID: roomId,


### PR DESCRIPTION
add "name" to "createQueryParameters" when creating a bigbluebutton conference through Element.

The name parameter is required by bigbluebutton since 2.4 (according to their documentation)

The widget now get's added to the room, and the conference (seems like) beeing created.

Joining the conference does not work yet, but i could not find why that is.