### PR TITLE
Stop logging BigBlueButton shared secrets

### DIFF
--- a/src/api/dimension/DimensionBigBlueButtonService.ts
+++ b/src/api/dimension/DimensionBigBlueButtonService.ts
@@ -362,9 +362,6 @@ export class DimensionBigBlueButtonService {
         // We URL encode each value as a browser would. If we don't, our resulting checksum will not match.
         const widgetQueryString = this.queryStringFromObject(queryParameters, encodeAsBrowser);
 
-        LogService.info("BigBlueButton", "Built widget string:" + widgetQueryString);
-        LogService.info("BigBlueButton", "Hashing:" + apiCallName + widgetQueryString + config.bigbluebutton.sharedSecret);
-
         // Hash the api name and query parameters to get the checksum, and add it to the set of query parameters
         return sha256(apiCallName + widgetQueryString + config.bigbluebutton.sharedSecret);
     }


### PR DESCRIPTION
This commit removes some sensitive information from runtime logs at the INFO level. Specifically the BigBlueButton shared secret :)